### PR TITLE
Add the `Server: EC2ws` response header

### DIFF
--- a/server.go
+++ b/server.go
@@ -51,6 +51,7 @@ type appHandler func(http.ResponseWriter, *http.Request)
 
 func (fn appHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	log.Infof("Requesting %s", r.RequestURI)
+	w.Header().Set("Server", "EC2ws")
 	fn(w, r)
 }
 


### PR DESCRIPTION
which is commonly used to identify which platform (like EC2, GCE) the requestor is running on.

I say it is common according to [google search result](https://www.google.com/search?q=%22Server%3A+EC2ws%22).
Though I could not find any official documentation about it, this change makes aws-mock-metadata more similar to actual EC2 metadata service anyway.

fixes #3