### PR TITLE
Note on how to mock metadata service without installing iptables on docker images

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,10 @@ before starting your program:
 
 	iptables -t nat -A OUTPUT -d 169.254.169.254 -j DNAT --to-destination ${HOST}
 
+Or if you don't want to modify your docker image, on your docker host (e.g. the one created with docker-machine):
+
+	iptables -t nat -A PREROUTING -d 169.254.169.254 -j DNAT --to-destination ${HOST}
+
 ## Development
 
 ### Configuration


### PR DESCRIPTION
This change adds a little note to README about how to connect 169.254.169.254 to an instance of aws-mock-metadata WITHOUT installing iptables on docker images.
We run iptables on docker host instead.

It may be useful when you want to locally run a part of integration tests (which you won't like to modify docker images on that phase) involving a docker image relies on the metadata service which formerly required you to prepare actual AWS EC2 instancse.