### PR TITLE
Merge CpuID's fork with upstream

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,15 @@
-FROM alpine:3.3
+FROM golang:1.9.4-alpine3.6
 MAINTAINER Jerome Touffe-Blin <jtblin@gmail.com>
+RUN apk add --no-cache git
+WORKDIR /go/src/app
+COPY . .
+RUN go get -d -v ./...
+RUN go install -v ./...
 
-RUN apk --update add ca-certificates \
-	&& rm -rf /var/cache/apk/*
-
-ADD /bin/aws-mock-metadata-linux /bin/aws-mock-metadata
-
+# This image is like 13MB exported... :)
+FROM alpine:3.6
+RUN apk add --no-cache ca-certificates
+WORKDIR /root/
+COPY --from=0 /go/bin/app ./aws-mock-metadata
 EXPOSE 45000
-ENTRYPOINT ["aws-mock-metadata"]
+CMD ["./aws-mock-metadata", "--app-port", "45000"]

--- a/app.go
+++ b/app.go
@@ -31,7 +31,7 @@ func main() {
 		log.SetLevel(log.DebugLevel)
 	}
 
-	app.NewServer()
+	app.StartServer()
 }
 
 func (app *App) addFlags(fs *pflag.FlagSet) {

--- a/app.go
+++ b/app.go
@@ -10,14 +10,16 @@ import (
 // App encapsulates all of the parameters necessary for starting up
 // an aws mock metadata server. These can either be set via command line or directly.
 type App struct {
-	AmiID                 string
-	AvailabilityZone      string
-	AppPort               string
-	Hostname              string
-	InstanceID            string
-	InstanceType          string
-	MacAddress            string
-	PrivateIp             string
+	AmiID            string
+	AvailabilityZone string
+	AppPort          string
+	Hostname         string
+	InstanceID       string
+	InstanceType     string
+	MacAddress       string
+	PrivateIp        string
+	// If set, will return mocked credentials to the IAM instance profile instead of using STS to retrieve real credentials.
+	MockInstanceProfile   bool
 	RoleArn               string
 	RoleName              string
 	Verbose               bool
@@ -47,6 +49,7 @@ func (app *App) addFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&app.InstanceType, "instance-type", app.InstanceType, "EC2 Instance Type")
 	fs.StringVar(&app.MacAddress, "mac-address", app.MacAddress, "ENI MAC Address")
 	fs.StringVar(&app.PrivateIp, "private-ip", app.PrivateIp, "ENI Private IP")
+	fs.BoolVar(&app.MockInstanceProfile, "mock-instance-profile", false, "Use mocked IAM Instance Profile credentials (instead of STS generated credentials)")
 	fs.StringVar(&app.RoleArn, "role-arn", app.RoleArn, "IAM Role ARN")
 	fs.StringVar(&app.RoleName, "role-name", app.RoleName, "IAM Role Name")
 	fs.BoolVar(&app.Verbose, "verbose", false, "Verbose")

--- a/app.go
+++ b/app.go
@@ -15,6 +15,8 @@ type App struct {
 	AppPort               string
 	Hostname              string
 	InstanceID            string
+	InstanceType          string
+	MacAddress            string
 	PrivateIp             string
 	RoleArn               string
 	RoleName              string
@@ -41,8 +43,10 @@ func (app *App) addFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&app.AvailabilityZone, "availability-zone", app.AvailabilityZone, "Availability Zone")
 	fs.StringVar(&app.AppPort, "app-port", app.AppPort, "HTTP Port")
 	fs.StringVar(&app.Hostname, "hostname", app.Hostname, "EC2 Instance Hostname")
-	fs.StringVar(&app.InstanceID, "instance-id", app.InstanceID, "EC2 instance id")
-	fs.StringVar(&app.PrivateIp, "private-ip", app.PrivateIp, "Private IP")
+	fs.StringVar(&app.InstanceID, "instance-id", app.InstanceID, "EC2 Instance ID")
+	fs.StringVar(&app.InstanceType, "instance-type", app.InstanceType, "EC2 Instance Type")
+	fs.StringVar(&app.MacAddress, "mac-address", app.MacAddress, "ENI MAC Address")
+	fs.StringVar(&app.PrivateIp, "private-ip", app.PrivateIp, "ENI Private IP")
 	fs.StringVar(&app.RoleArn, "role-arn", app.RoleArn, "IAM Role ARN")
 	fs.StringVar(&app.RoleName, "role-name", app.RoleName, "IAM Role Name")
 	fs.BoolVar(&app.Verbose, "verbose", false, "Verbose")

--- a/app.go
+++ b/app.go
@@ -10,6 +10,7 @@ import (
 // App encapsulates all of the parameters necessary for starting up
 // an aws mock metadata server. These can either be set via command line or directly.
 type App struct {
+	AmiID                 string
 	AvailabilityZone      string
 	AppPort               string
 	Hostname              string
@@ -36,14 +37,15 @@ func main() {
 }
 
 func (app *App) addFlags(fs *pflag.FlagSet) {
-	fs.StringVar(&app.AvailabilityZone, "availability-zone", app.AvailabilityZone, "Availability zone")
-	fs.StringVar(&app.AppPort, "app-port", app.AppPort, "Http port")
-	fs.StringVar(&app.Hostname, "hostname", app.Hostname, "ec2 instance hostname")
-	fs.StringVar(&app.InstanceID, "instance-id", app.InstanceID, "ec2 instance id")
-	fs.StringVar(&app.PrivateIp, "private-ip", app.PrivateIp, "Private ip")
-	fs.StringVar(&app.RoleArn, "role-arn", app.RoleArn, "IAM role Arn")
-	fs.StringVar(&app.RoleName, "role-name", app.RoleName, "IAM role name")
+	fs.StringVar(&app.AmiID, "ami-id", app.AmiID, "EC2 Instance AMI ID")
+	fs.StringVar(&app.AvailabilityZone, "availability-zone", app.AvailabilityZone, "Availability Zone")
+	fs.StringVar(&app.AppPort, "app-port", app.AppPort, "HTTP Port")
+	fs.StringVar(&app.Hostname, "hostname", app.Hostname, "EC2 Instance Hostname")
+	fs.StringVar(&app.InstanceID, "instance-id", app.InstanceID, "EC2 instance id")
+	fs.StringVar(&app.PrivateIp, "private-ip", app.PrivateIp, "Private IP")
+	fs.StringVar(&app.RoleArn, "role-arn", app.RoleArn, "IAM Role ARN")
+	fs.StringVar(&app.RoleName, "role-name", app.RoleName, "IAM Role Name")
 	fs.BoolVar(&app.Verbose, "verbose", false, "Verbose")
-	fs.StringVar(&app.VpcID, "vpc-id", app.VpcID, "VPC id")
+	fs.StringVar(&app.VpcID, "vpc-id", app.VpcID, "VPC ID")
 	fs.BoolVar(&app.NoSchemeHostRedirects, "no-scheme-host-redirects", app.NoSchemeHostRedirects, "Disable the scheme://host prefix in Location redirect headers")
 }

--- a/app.go
+++ b/app.go
@@ -10,15 +10,16 @@ import (
 // App encapsulates all of the parameters necessary for starting up
 // an aws mock metadata server. These can either be set via command line or directly.
 type App struct {
-	AvailabilityZone string
-	AppPort          string
-	Hostname         string
-	InstanceID       string
-	PrivateIp        string
-	RoleArn          string
-	RoleName         string
-	Verbose          bool
-	VpcID            string
+	AvailabilityZone      string
+	AppPort               string
+	Hostname              string
+	InstanceID            string
+	PrivateIp             string
+	RoleArn               string
+	RoleName              string
+	Verbose               bool
+	VpcID                 string
+	NoSchemeHostRedirects bool
 }
 
 func main() {
@@ -44,4 +45,5 @@ func (app *App) addFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&app.RoleName, "role-name", app.RoleName, "IAM role name")
 	fs.BoolVar(&app.Verbose, "verbose", false, "Verbose")
 	fs.StringVar(&app.VpcID, "vpc-id", app.VpcID, "VPC id")
+	fs.BoolVar(&app.NoSchemeHostRedirects, "no-scheme-host-redirects", app.NoSchemeHostRedirects, "Disable the scheme://host prefix in Location redirect headers")
 }

--- a/main_test.go
+++ b/main_test.go
@@ -20,7 +20,10 @@ func TestMain(m *testing.M) {
 	// AppPort not required
 	app.Hostname = "testhostname"
 	app.InstanceID = "i-asdfasdf"
+	app.InstanceType = "t2.micro"
+	app.MacAddress = "00:aa:bb:cc:dd:ee"
 	app.PrivateIp = "10.20.30.40"
+	app.RoleName = "some-instance-profile"
 	// No RoleArn or RoleName needed for current test coverage
 	app.VpcID = "vpc-asdfasdf"
 	testServer = httptest.NewServer(app.NewServer())

--- a/main_test.go
+++ b/main_test.go
@@ -15,6 +15,7 @@ func TestMain(m *testing.M) {
 	// Setup the test API
 	app := &App{}
 	// Mock parameters
+	app.AmiID = "ami-asdfasdf"
 	app.AvailabilityZone = "us-east-1a"
 	// AppPort not required
 	app.Hostname = "testhostname"

--- a/main_test.go
+++ b/main_test.go
@@ -22,6 +22,7 @@ func TestMain(m *testing.M) {
 	app.InstanceID = "i-asdfasdf"
 	app.InstanceType = "t2.micro"
 	app.MacAddress = "00:aa:bb:cc:dd:ee"
+	app.MockInstanceProfile = true
 	app.PrivateIp = "10.20.30.40"
 	app.RoleName = "some-instance-profile"
 	// No RoleArn or RoleName needed for current test coverage

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,30 @@
+package main
+
+import (
+	"net/http/httptest"
+	"os"
+	"testing"
+)
+
+// Not a fan of globals, but it's the only sane way to pass an httptest instance into each of the tests...
+var (
+	testServer *httptest.Server
+)
+
+func TestMain(m *testing.M) {
+	// Setup the test API
+	app := &App{}
+	// Mock parameters
+	app.AvailabilityZone = "us-east-1a"
+	// AppPort not required
+	app.Hostname = "testhostname"
+	app.InstanceID = "i-asdfasdf"
+	app.PrivateIp = "10.20.30.40"
+	// No RoleArn or RoleName needed for current test coverage
+	app.VpcID = "vpc-asdfasdf"
+	testServer = httptest.NewServer(app.NewServer())
+	defer testServer.Close()
+
+	// Run the tests
+	os.Exit(m.Run())
+}

--- a/server.go
+++ b/server.go
@@ -43,6 +43,7 @@ func (app *App) NewServer() *mux.Router {
 
 // Provides the per date-versioned prefix routes
 func (app *App) serverSubRouter(sr *mux.Router) {
+	sr.Handle("/", appHandler(app.secondLevelHandler))
 	s := sr.PathPrefix("/meta-data").Subrouter()
 	s.Handle("/instance-id", appHandler(app.instanceIDHandler))
 	s.Handle("/local-hostname", appHandler(app.localHostnameHandler))
@@ -98,6 +99,12 @@ func (app *App) rootHandler(w http.ResponseWriter, r *http.Request) {
 2016-06-30
 2016-09-02
 latest`)
+}
+
+func (app *App) secondLevelHandler(w http.ResponseWriter, r *http.Request) {
+	write(w, `dynamic
+meta-data
+user-data`)
 }
 
 func (app *App) instanceIDHandler(w http.ResponseWriter, r *http.Request) {

--- a/server.go
+++ b/server.go
@@ -44,7 +44,7 @@ func (app *App) NewServer() *mux.Router {
 
 // Provides the per date-versioned prefix routes
 func (app *App) serverSubRouter(sr *mux.Router) {
-	// sr.Handle("", appHandler(app.trailingSlashRedirect))
+	sr.Handle("", appHandler(app.trailingSlashRedirect))
 	sr.Handle("/", appHandler(app.secondLevelHandler))
 	s := sr.PathPrefix("/meta-data").Subrouter()
 	s.Handle("/", appHandler(app.metaDataHandler))

--- a/server.go
+++ b/server.go
@@ -62,6 +62,7 @@ func (app *App) NewServer() *mux.Router {
 }
 
 // Provides the versioned (normally 1.0, YYYY-MM-DD or latest) prefix routes
+// TODO: conditional out the namespaces that don't exist on selected API versions
 func (app *App) versionSubRouter(sr *mux.Router, version string) {
 	sr.Handle("", appHandler(app.trailingSlashRedirect))
 	sr.Handle("/", appHandler(app.secondLevelHandler))
@@ -69,6 +70,7 @@ func (app *App) versionSubRouter(sr *mux.Router, version string) {
 	d := sr.PathPrefix("/dynamic").Subrouter()
 	d.Handle("", appHandler(app.trailingSlashRedirect))
 	d.Handle("/", appHandler(app.dynamicHandler))
+
 	ii := d.PathPrefix("/instance-identity").Subrouter()
 	ii.Handle("", appHandler(app.trailingSlashRedirect))
 	ii.Handle("/", appHandler(app.instanceIdentityHandler))
@@ -124,6 +126,12 @@ func (app *App) versionSubRouter(sr *mux.Router, version string) {
 	m.Handle("/mac", appHandler(app.macHandler))
 	m.Handle("/mac/", appHandler(app.macHandler))
 
+	me := m.PathPrefix("/metrics").Subrouter()
+	me.Handle("", appHandler(app.trailingSlashRedirect))
+	me.Handle("/", appHandler(app.metricsHandler))
+	me.Handle("/vhostmd", appHandler(app.metricsVhostmdHandler))
+	me.Handle("/vhostmd/", appHandler(app.metricsVhostmdHandler))
+
 	n := m.PathPrefix("/network").Subrouter()
 	n.Handle("", appHandler(app.trailingSlashRedirect))
 	n.Handle("/", appHandler(app.networkHandler))
@@ -143,23 +151,27 @@ func (app *App) versionSubRouter(sr *mux.Router, version string) {
 	// TODO: expand API coverage
 	nimaddr.Handle("/vpc-id", appHandler(app.vpcHandler))
 
-	me := m.PathPrefix("/metrics").Subrouter()
-	me.Handle("", appHandler(app.trailingSlashRedirect))
-	me.Handle("/", appHandler(app.metricsHandler))
-	me.Handle("/vhostmd", appHandler(app.metricsVhostmdHandler))
-	me.Handle("/vhostmd/", appHandler(app.metricsVhostmdHandler))
-
 	p := m.PathPrefix("/placement").Subrouter()
 	p.Handle("/availability-zone", appHandler(app.availabilityZoneHandler))
+
+	m.Handle("/profile", appHandler(app.profileHandler))
+	m.Handle("/profile/", appHandler(app.profileHandler))
+	m.Handle("/public-hostname", appHandler(app.hostnameHandler))
+	m.Handle("/public-hostname/", appHandler(app.hostnameHandler))
 
 	sr.Handle("/{path:.*}", appHandler(app.notFoundHandler))
 	d.Handle("/{path:.*}", appHandler(app.notFoundHandler))
 	ii.Handle("/{path:.*}", appHandler(app.notFoundHandler))
 	m.Handle("/{path:.*}", appHandler(app.notFoundHandler))
 	bdm.Handle("/{path:.*}", appHandler(app.notFoundHandler))
-	p.Handle("/{path:.*}", appHandler(app.notFoundHandler))
 	i.Handle("/{path:.*}", appHandler(app.notFoundHandler))
+	isc.Handle("/{path:.*}", appHandler(app.notFoundHandler))
+	me.Handle("/{path:.*}", appHandler(app.notFoundHandler))
 	n.Handle("/{path:.*}", appHandler(app.notFoundHandler))
+	ni.Handle("/{path:.*}", appHandler(app.notFoundHandler))
+	nim.Handle("/{path:.*}", appHandler(app.notFoundHandler))
+	nimaddr.Handle("/{path:.*}", appHandler(app.notFoundHandler))
+	p.Handle("/{path:.*}", appHandler(app.notFoundHandler))
 }
 
 type appHandler func(http.ResponseWriter, *http.Request)
@@ -402,6 +414,10 @@ func (app *App) nimAddrDeviceNumberHandler(w http.ResponseWriter, r *http.Reques
 
 func (app *App) nimAddrInterfaceIdHandler(w http.ResponseWriter, r *http.Request) {
 	write(w, `eni-asdfasdf`)
+}
+
+func (app *App) profileHandler(w http.ResponseWriter, r *http.Request) {
+	write(w, `default-hvm`)
 }
 
 func (app *App) vpcHandler(w http.ResponseWriter, r *http.Request) {

--- a/server.go
+++ b/server.go
@@ -12,8 +12,16 @@ import (
 	"github.com/gorilla/mux"
 )
 
-// NewServer creates and starts a new http server
-func (app *App) NewServer() {
+// StartServer starts a newly created http server
+func (app *App) StartServer() {
+	log.Infof("Listening on port %s", app.AppPort)
+	if err := http.ListenAndServe(":"+app.AppPort, app.NewServer()); err != nil {
+		log.Fatalf("Error creating http server: %+v", err)
+	}
+}
+
+// NewServer creates a new http server (starting handled separately to allow test suites to reuse)
+func (app *App) NewServer() *mux.Router {
 	r := mux.NewRouter()
 	r.Handle("/", appHandler(app.rootHandler))
 
@@ -30,10 +38,7 @@ func (app *App) NewServer() {
 
 	r.Handle("/{path:.*}", appHandler(app.notFoundHandler))
 
-	log.Infof("Listening on port %s", app.AppPort)
-	if err := http.ListenAndServe(":"+app.AppPort, r); err != nil {
-		log.Fatalf("Error creating http server: %+v", err)
-	}
+	return r
 }
 
 // Provides the per date-versioned prefix routes
@@ -88,6 +93,10 @@ func (app *App) rootHandler(w http.ResponseWriter, r *http.Request) {
 2012-01-12
 2014-02-25
 2014-11-05
+2015-10-20
+2016-04-19
+2016-06-30
+2016-09-02
 latest`)
 }
 

--- a/server.go
+++ b/server.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"time"
 
@@ -47,6 +48,7 @@ func (app *App) serverSubRouter(sr *mux.Router) {
 	sr.Handle("", appHandler(app.trailingSlashRedirect))
 	sr.Handle("/", appHandler(app.secondLevelHandler))
 	s := sr.PathPrefix("/meta-data").Subrouter()
+	s.Handle("", appHandler(app.trailingSlashRedirect))
 	s.Handle("/", appHandler(app.metaDataHandler))
 	s.Handle("/instance-id", appHandler(app.instanceIDHandler))
 	s.Handle("/local-hostname", appHandler(app.localHostnameHandler))
@@ -155,7 +157,12 @@ func (app *App) securityCredentialsHandler(w http.ResponseWriter, r *http.Reques
 }
 
 func (app *App) trailingSlashRedirect(w http.ResponseWriter, r *http.Request) {
-	w.Header().Set("Location", r.URL.String()+"/")
+	location := ""
+	if app.NoSchemeHostRedirects == false {
+		location = "http://169.254.169.254"
+	}
+	location = fmt.Sprintf("%s%s/", location, r.URL.String())
+	w.Header().Set("Location", location)
 	w.WriteHeader(301)
 }
 

--- a/server_test.go
+++ b/server_test.go
@@ -377,6 +377,13 @@ func TestLatestMetaDataNIMAddrInterfaceId(t *testing.T) {
 
 // TODO: coverage for the network/interfaces/macs/mac_addr/... namespaces...
 
+func TestLatestMetaDataProfile(t *testing.T) {
+	expected_body := `default-hvm`
+
+	doBodyTest(t, "/latest/meta-data/profile", expected_body)
+	doBodyTest(t, "/latest/meta-data/profile/", expected_body)
+}
+
 func TestLatestUserData(t *testing.T) {
 	// TODO: /latest/user-data returns a 404 if none exists... or if one exists, will return it?
 	// should we expose this in the API? not implemented right now. could be useful...

--- a/server_test.go
+++ b/server_test.go
@@ -19,7 +19,7 @@ func doBodyTest(t *testing.T, uri string, expected_body string) {
 		t.Fatal(err)
 	}
 	if string(body) != expected_body {
-		t.Errorf("%s : Expected\n%s\ngot\n%s", uri, expected_body, string(body))
+		t.Errorf("%s : Expected\n\n%s\n\ngot\n\n%s", uri, expected_body, string(body))
 	}
 }
 
@@ -67,12 +67,38 @@ latest`
 }
 
 func TestLatest(t *testing.T) {
-	expected_body := `dynamic
-meta-data
-user-data`
+	// expected_body := `dynamic
+	// meta-data
+	// user-data`
 
 	doRedirectTest(t, "/latest", "/latest/")
-	doBodyTest(t, "/latest/", expected_body)
+	//doBodyTest(t, "/latest/", expected_body)
 }
 
-// TODO: iam/ subdirectory only appears in latest/ (and other date namespaces) if an IAM instance profile is attached, omitted otherwise. handle elegantly
+func TestLatestMetaData(t *testing.T) {
+	// NOTE: iam/ only appears if there is an IAM Instance Profile attached to the instance. assuming available for simulation purposes for now.
+	expected_body := `ami-id
+ami-launch-index
+ami-manifest-path
+block-device-mapping/
+hostname
+iam/
+instance-action
+instance-id
+instance-type
+local-hostname
+local-ipv4
+mac
+metrics/
+network/
+placement/
+profile
+public-hostname
+public-ipv4
+reservation-id
+security-groups
+services/`
+
+	doRedirectTest(t, "/latest/meta-data", "/latest/meta-data/")
+	doBodyTest(t, "/latest/meta-data/", expected_body)
+}

--- a/server_test.go
+++ b/server_test.go
@@ -98,7 +98,8 @@ func TestLatestDynamic(t *testing.T) {
 func TestLatestDynamicInstanceIdentity(t *testing.T) {
 	expected_body := `document
 pkcs7
-signature`
+signature
+`
 
 	doRedirectTest(t, "/latest/dynamic/instance-identity", "/latest/dynamic/instance-identity/")
 	doBodyTest(t, "/latest/dynamic/instance-identity/", expected_body)

--- a/server_test.go
+++ b/server_test.go
@@ -7,9 +7,20 @@ import (
 	"testing"
 )
 
+// Custom HTTP client, that defines the redirect behavior.
+// Don't follow 301s, return them so the tests can correctly identify and validate responses
+func testHttpClient() *http.Client {
+	return &http.Client{
+		CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
+	}
+}
+
 // DRY
 func doBodyTest(t *testing.T, uri string, expected_body string) {
-	res, err := http.Get(testServer.URL + uri)
+	client := testHttpClient()
+	res, err := client.Get(testServer.URL + uri)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -25,7 +36,8 @@ func doBodyTest(t *testing.T, uri string, expected_body string) {
 
 // Some URIs have 301 redirects on the real metadata service
 func doRedirectTest(t *testing.T, uri string, expected_location_uri string) {
-	res, err := http.Get(testServer.URL + uri)
+	client := testHttpClient()
+	res, err := client.Get(testServer.URL + uri)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/server_test.go
+++ b/server_test.go
@@ -105,6 +105,42 @@ signature
 	doBodyTest(t, "/latest/dynamic/instance-identity/", expected_body)
 }
 
+func TestLatestDynamicInstanceIdentityDocument(t *testing.T) {
+	expected_body := `{
+  "instanceId" : "i-asdfasdf",
+  "billingProducts" : null,
+  "imageId" : "ami-asdfasdf",
+  "architecture" : "x86_64",
+  "pendingTime" : "",
+  "instanceType" : "t2.micro",
+  "accountId" : "",
+  "kernelId" : null,
+  "ramdiskId" : null,
+  "region" : "us-east-1",
+  "version" : "2010-08-31",
+  "availabilityZone" : "us-east-1a",
+  "devpayProductCodes" : null,
+  "privateIp" : "10.20.30.40"
+}`
+
+	doBodyTest(t, "/latest/dynamic/instance-identity/document", expected_body)
+	doBodyTest(t, "/latest/dynamic/instance-identity/document/", expected_body)
+}
+
+func TestLatestDynamicInstanceIdentityPkcs7(t *testing.T) {
+	expected_body := `TODO-correct-output`
+
+	doBodyTest(t, "/latest/dynamic/instance-identity/pkcs7", expected_body)
+	doBodyTest(t, "/latest/dynamic/instance-identity/pkcs7/", expected_body)
+}
+
+func TestLatestDynamicInstanceIdentitySignature(t *testing.T) {
+	expected_body := `TODO-correct-output`
+
+	doBodyTest(t, "/latest/dynamic/instance-identity/signature", expected_body)
+	doBodyTest(t, "/latest/dynamic/instance-identity/signature/", expected_body)
+}
+
 func TestLatestMetaData(t *testing.T) {
 	// NOTE: iam/ only appears if there is an IAM Instance Profile attached to the instance. assuming available for simulation purposes for now.
 	expected_body := `ami-id
@@ -131,6 +167,56 @@ services/`
 
 	doRedirectTest(t, "/latest/meta-data", "/latest/meta-data/")
 	doBodyTest(t, "/latest/meta-data/", expected_body)
+}
+
+func TestLatestMetaDataAmiId(t *testing.T) {
+	expected_body := `ami-asdfasdf`
+
+	doBodyTest(t, "/latest/meta-data/ami-id", expected_body)
+	doBodyTest(t, "/latest/meta-data/ami-id/", expected_body)
+}
+
+func TestLatestMetaDataAmiLaunchIndex(t *testing.T) {
+	expected_body := `0`
+
+	doBodyTest(t, "/latest/meta-data/ami-launch-index", expected_body)
+	doBodyTest(t, "/latest/meta-data/ami-launch-index/", expected_body)
+}
+
+func TestLatestMetaDataAmiManifestPath(t *testing.T) {
+	expected_body := `(unknown)`
+
+	doBodyTest(t, "/latest/meta-data/ami-manifest-path", expected_body)
+	doBodyTest(t, "/latest/meta-data/ami-manifest-path/", expected_body)
+}
+
+func TestLatestMetaDataBlockDeviceMapping(t *testing.T) {
+	expected_body := `ami
+root`
+
+	doRedirectTest(t, "/latest/meta-data/block-device-mapping", "/latest/meta-data/block-device-mapping/")
+	doBodyTest(t, "/latest/meta-data/block-device-mapping/", expected_body)
+}
+
+func TestLatestMetaDataBlockDeviceMappingAmi(t *testing.T) {
+	expected_body := `/dev/xvda`
+
+	doBodyTest(t, "/latest/meta-data/block-device-mapping/ami", expected_body)
+	doBodyTest(t, "/latest/meta-data/block-device-mapping/ami/", expected_body)
+}
+
+func TestLatestMetaDataBlockDeviceMappingRoot(t *testing.T) {
+	expected_body := `/dev/xvda`
+
+	doBodyTest(t, "/latest/meta-data/block-device-mapping/root", expected_body)
+	doBodyTest(t, "/latest/meta-data/block-device-mapping/root/", expected_body)
+}
+
+func TestLatestMetaDataHostname(t *testing.T) {
+	expected_body := `testhostname`
+
+	doBodyTest(t, "/latest/meta-data/hostname", expected_body)
+	doBodyTest(t, "/latest/meta-data/hostname/", expected_body)
 }
 
 func TestLatestUserData(t *testing.T) {

--- a/server_test.go
+++ b/server_test.go
@@ -79,12 +79,29 @@ latest`
 }
 
 func TestLatest(t *testing.T) {
-	// expected_body := `dynamic
-	// meta-data
-	// user-data`
+	expected_body := `dynamic
+meta-data
+user-data`
 
 	doRedirectTest(t, "/latest", "/latest/")
-	//doBodyTest(t, "/latest/", expected_body)
+	doBodyTest(t, "/latest/", expected_body)
+}
+
+func TestLatestDynamic(t *testing.T) {
+	expected_body := `instance-identity/
+`
+
+	doRedirectTest(t, "/latest/dynamic", "/latest/dynamic/")
+	doBodyTest(t, "/latest/dynamic/", expected_body)
+}
+
+func TestLatestDynamicInstanceIdentity(t *testing.T) {
+	expected_body := `document
+pkcs7
+signature`
+
+	doRedirectTest(t, "/latest/dynamic/instance-identity", "/latest/dynamic/instance-identity/")
+	doBodyTest(t, "/latest/dynamic/instance-identity/", expected_body)
 }
 
 func TestLatestMetaData(t *testing.T) {
@@ -113,4 +130,9 @@ services/`
 
 	doRedirectTest(t, "/latest/meta-data", "/latest/meta-data/")
 	doBodyTest(t, "/latest/meta-data/", expected_body)
+}
+
+func TestLatestUserData(t *testing.T) {
+	// TODO: /latest/user-data returns a 404 if none exists... or if one exists, will return it?
+	// should we expose this in the API? not implemented right now. could be useful...
 }

--- a/server_test.go
+++ b/server_test.go
@@ -1,0 +1,44 @@
+package main
+
+import (
+	"io/ioutil"
+	"net/http"
+	"testing"
+)
+
+func TestRoot(t *testing.T) {
+	expected_body := `1.0
+2007-01-19
+2007-03-01
+2007-08-29
+2007-10-10
+2007-12-15
+2008-02-01
+2008-09-01
+2009-04-04
+2011-01-01
+2011-05-01
+2012-01-12
+2014-02-25
+2014-11-05
+2015-10-20
+2016-04-19
+2016-06-30
+2016-09-02
+latest`
+
+	res, err := http.Get(testServer.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	body, err := ioutil.ReadAll(res.Body)
+	defer res.Body.Close()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(body) != expected_body {
+		t.Errorf("Expected\n%s\ngot\n%s", expected_body, string(body))
+	}
+}
+
+// TODO: iam/ subdirectory only appears in latest/ (and other date namespaces) if an IAM instance profile is attached, omitted otherwise. handle elegantly

--- a/server_test.go
+++ b/server_test.go
@@ -219,6 +219,164 @@ func TestLatestMetaDataHostname(t *testing.T) {
 	doBodyTest(t, "/latest/meta-data/hostname/", expected_body)
 }
 
+func TestLatestMetaDataIam(t *testing.T) {
+	expected_body := `info
+security-credentials/`
+
+	doRedirectTest(t, "/latest/meta-data/iam", "/latest/meta-data/iam/")
+	doBodyTest(t, "/latest/meta-data/iam/", expected_body)
+}
+
+func TestLatestMetaDataIamInfo(t *testing.T) {
+	expected_body := `{
+  "Code" : "Success",
+  "LastUpdated" : "2018-02-26T23:50:00Z",
+  "InstanceProfileArn" : "arn:aws:iam::123456789012:instance-profile/some-instance-profile",
+  "InstanceProfileId" : "some-instance-profile-id"
+}`
+
+	doBodyTest(t, "/latest/meta-data/iam/info", expected_body)
+	doBodyTest(t, "/latest/meta-data/iam/info/", expected_body)
+}
+
+func TestLatestMetaDataIamSecurityCredentials(t *testing.T) {
+	expected_body := `some-instance-profile`
+
+	doRedirectTest(t, "/latest/meta-data/iam/security-credentials", "/latest/meta-data/iam/security-credentials/")
+	doBodyTest(t, "/latest/meta-data/iam/security-credentials/", expected_body)
+}
+
+func TestLatestMetaDataIamSecurityCredentialsSomeInstanceProfile(t *testing.T) {
+	expected_body := `{
+  "Code" : "Success",
+  "LastUpdated" : "2018-02-27T00:50:01Z",
+  "Type" : "AWS-HMAC",
+  "AccessKeyId" : "some-access-key-id",
+  "SecretAccessKey" : "some-secret-access-key",
+  "Token" : "some-token",
+  "Expiration" : "2018-02-27T07:07:02Z"
+}`
+
+	doBodyTest(t, "/latest/meta-data/iam/security-credentials/some-instance-profile", expected_body)
+	doBodyTest(t, "/latest/meta-data/iam/security-credentials/some-instance-profile/", expected_body)
+}
+
+func TestLatestMetaDataInstanceAction(t *testing.T) {
+	expected_body := `none`
+
+	doBodyTest(t, "/latest/meta-data/instance-action", expected_body)
+	doBodyTest(t, "/latest/meta-data/instance-action/", expected_body)
+}
+
+func TestLatestMetaDataInstanceId(t *testing.T) {
+	expected_body := `i-asdfasdf`
+
+	doBodyTest(t, "/latest/meta-data/instance-id", expected_body)
+	doBodyTest(t, "/latest/meta-data/instance-id/", expected_body)
+}
+
+func TestLatestMetaDataInstanceType(t *testing.T) {
+	expected_body := `t2.micro`
+
+	doBodyTest(t, "/latest/meta-data/instance-type", expected_body)
+	doBodyTest(t, "/latest/meta-data/instance-type/", expected_body)
+}
+
+func TestLatestMetaDataLocalHostname(t *testing.T) {
+	expected_body := `testhostname`
+
+	doBodyTest(t, "/latest/meta-data/local-hostname", expected_body)
+	doBodyTest(t, "/latest/meta-data/local-hostname/", expected_body)
+}
+
+func TestLatestMetaDataLocalIpv4(t *testing.T) {
+	expected_body := `10.20.30.40`
+
+	doBodyTest(t, "/latest/meta-data/local-ipv4", expected_body)
+	doBodyTest(t, "/latest/meta-data/local-ipv4/", expected_body)
+}
+
+func TestLatestMetaDataMac(t *testing.T) {
+	expected_body := `00:aa:bb:cc:dd:ee`
+
+	doBodyTest(t, "/latest/meta-data/mac", expected_body)
+	doBodyTest(t, "/latest/meta-data/mac/", expected_body)
+}
+
+func TestLatestMetaDataMetrics(t *testing.T) {
+	expected_body := `vhostmd`
+
+	doRedirectTest(t, "/latest/meta-data/metrics", "/latest/meta-data/metrics/")
+	doBodyTest(t, "/latest/meta-data/metrics/", expected_body)
+}
+
+func TestLatestMetaDataMetricsVhostMd(t *testing.T) {
+	// No idea what actually lives here right now, leaving as a placeholder.
+	expected_body := `<?xml version="1.0" encoding="UTF-8"?>`
+
+	doBodyTest(t, "/latest/meta-data/metrics/vhostmd", expected_body)
+	doBodyTest(t, "/latest/meta-data/metrics/vhostmd/", expected_body)
+}
+
+func TestLatestMetaDataNetwork(t *testing.T) {
+	expected_body := `interfaces/`
+
+	doRedirectTest(t, "/latest/meta-data/network", "/latest/meta-data/network/")
+	doBodyTest(t, "/latest/meta-data/network/", expected_body)
+}
+
+func TestLatestMetaDataNetworkInterfaces(t *testing.T) {
+	expected_body := `macs/`
+
+	doRedirectTest(t, "/latest/meta-data/network/interfaces", "/latest/meta-data/network/interfaces/")
+	doBodyTest(t, "/latest/meta-data/network/interfaces/", expected_body)
+}
+
+func TestLatestMetaDataNetworkInterfacesMacs(t *testing.T) {
+	expected_body := `00:aa:bb:cc:dd:ee/`
+
+	doRedirectTest(t, "/latest/meta-data/network/interfaces/macs", "/latest/meta-data/network/interfaces/macs/")
+	doBodyTest(t, "/latest/meta-data/network/interfaces/macs/", expected_body)
+}
+
+func TestLatestMetaDataNetworkInterfacesMacsAddr(t *testing.T) {
+	expected_body := `device-number
+interface-id
+ipv4-associations/
+local-hostname
+local-ipv4s
+mac
+owner-id
+public-hostname
+public-ipv4s
+security-group-ids
+security-groups
+subnet-id
+subnet-ipv4-cidr-block
+vpc-id
+vpc-ipv4-cidr-block
+vpc-ipv4-cidr-blocks`
+
+	doRedirectTest(t, "/latest/meta-data/network/interfaces/macs/00:aa:bb:cc:dd:ee", "/latest/meta-data/network/interfaces/macs/00:aa:bb:cc:dd:ee/")
+	doBodyTest(t, "/latest/meta-data/network/interfaces/macs/00:aa:bb:cc:dd:ee/", expected_body)
+}
+
+func TestLatestMetaDataNIMAddrDeviceNumber(t *testing.T) {
+	expected_body := `0`
+
+	doBodyTest(t, "/latest/meta-data/network/interfaces/macs/00:aa:bb:cc:dd:ee/device-number", expected_body)
+	doBodyTest(t, "/latest/meta-data/network/interfaces/macs/00:aa:bb:cc:dd:ee/device-number/", expected_body)
+}
+
+func TestLatestMetaDataNIMAddrInterfaceId(t *testing.T) {
+	expected_body := `eni-asdfasdf`
+
+	doBodyTest(t, "/latest/meta-data/network/interfaces/macs/00:aa:bb:cc:dd:ee/interface-id", expected_body)
+	doBodyTest(t, "/latest/meta-data/network/interfaces/macs/00:aa:bb:cc:dd:ee/interface-id/", expected_body)
+}
+
+// TODO: coverage for the network/interfaces/macs/mac_addr/... namespaces...
+
 func TestLatestUserData(t *testing.T) {
 	// TODO: /latest/user-data returns a 404 if none exists... or if one exists, will return it?
 	// should we expose this in the API? not implemented right now. could be useful...


### PR DESCRIPTION
- Dramatically expands the API endpoint list, including 301 redirects from common places + directory `/` listings
- Adds ability to return "mocked" instance profile credentials, which will not actually work but the response format is accurate
  - Initial motivator was for https://github.com/CpuID/ec2-mock which does not check the `Authorization` header as part of requests, but allows using existing client utilities which attempt to use Role/Instance Profile based auth
- Adds approx 80% test coverage over the methods
- Updated `Dockerfile` to use a multi-stage build, which produces a 13MB image (vs current 5MB) but the build process moves into Docker
  - [ ] I still need to update the `Makefile` + `README` at some point, may do it prior to merging