### PR TITLE
Feature - Add configurable network interface

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ build: *.go
 	gofmt -w=true .
 	go build -o bin/aws-mock-metadata $(GOBUILD_VERSION_ARGS) github.com/jtblin/aws-mock-metadata
 
-test: check
+test: build
 	go test
 
 junit-test: build

--- a/app.go
+++ b/app.go
@@ -12,6 +12,7 @@ import (
 type App struct {
 	AmiID            string
 	AvailabilityZone string
+	AppInterface     string
 	AppPort          string
 	Hostname         string
 	InstanceID       string
@@ -44,6 +45,7 @@ func main() {
 func (app *App) addFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&app.AmiID, "ami-id", app.AmiID, "EC2 Instance AMI ID")
 	fs.StringVar(&app.AvailabilityZone, "availability-zone", app.AvailabilityZone, "Availability Zone")
+	fs.StringVar(&app.AppInterface, "app-interface", app.AppInterface, "HTTP Network Interface")
 	fs.StringVar(&app.AppPort, "app-port", app.AppPort, "HTTP Port")
 	fs.StringVar(&app.Hostname, "hostname", app.Hostname, "EC2 Instance Hostname")
 	fs.StringVar(&app.InstanceID, "instance-id", app.InstanceID, "EC2 Instance ID")

--- a/app.go
+++ b/app.go
@@ -15,6 +15,7 @@ type App struct {
 	AppPort          string
 	Hostname         string
 	InstanceID       string
+	AccountID        string
 	InstanceType     string
 	MacAddress       string
 	PrivateIp        string
@@ -47,6 +48,7 @@ func (app *App) addFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&app.Hostname, "hostname", app.Hostname, "EC2 Instance Hostname")
 	fs.StringVar(&app.InstanceID, "instance-id", app.InstanceID, "EC2 Instance ID")
 	fs.StringVar(&app.InstanceType, "instance-type", app.InstanceType, "EC2 Instance Type")
+	fs.StringVar(&app.AccountID, "account-id", app.AccountID, "AWS Account ID")
 	fs.StringVar(&app.MacAddress, "mac-address", app.MacAddress, "ENI MAC Address")
 	fs.StringVar(&app.PrivateIp, "private-ip", app.PrivateIp, "ENI Private IP")
 	fs.BoolVar(&app.MockInstanceProfile, "mock-instance-profile", false, "Use mocked IAM Instance Profile credentials (instead of STS generated credentials)")

--- a/main_test.go
+++ b/main_test.go
@@ -21,6 +21,7 @@ func TestMain(m *testing.M) {
 	app.Hostname = "testhostname"
 	app.InstanceID = "i-asdfasdf"
 	app.InstanceType = "t2.micro"
+	app.AccountID = "123456789012"
 	app.MacAddress = "00:aa:bb:cc:dd:ee"
 	app.MockInstanceProfile = true
 	app.PrivateIp = "10.20.30.40"

--- a/server.go
+++ b/server.go
@@ -293,7 +293,7 @@ func (app *App) instanceIdentityDocumentHandler(w http.ResponseWriter, r *http.R
 		InstanceId:         app.InstanceID,
 		BillingProducts:    nil,
 		InstanceType:       app.InstanceType,
-		AccountId:          "123456789012",
+		AccountId:          app.AccountID,
 		ImageId:            app.AmiID,
 		PendingTime:        "2016-04-15T12:14:15Z",
 		Architecture:       "x86_64",

--- a/server.go
+++ b/server.go
@@ -18,8 +18,8 @@ import (
 
 // StartServer starts a newly created http server
 func (app *App) StartServer() {
-	log.Infof("Listening on port %s", app.AppPort)
-	if err := http.ListenAndServe(":"+app.AppPort, app.NewServer()); err != nil {
+	log.Infof("Listening on port %s:%s", app.AppInterface, app.AppPort)
+	if err := http.ListenAndServe(app.AppInterface+":"+app.AppPort, app.NewServer()); err != nil {
 		log.Fatalf("Error creating http server: %+v", err)
 	}
 }

--- a/server.go
+++ b/server.go
@@ -177,6 +177,7 @@ func (app *App) versionSubRouter(sr *mux.Router, version string) {
 
 	p := m.PathPrefix("/placement").Subrouter()
 	p.Handle("/availability-zone", appHandler(app.availabilityZoneHandler))
+	p.Handle("/region", appHandler(app.regionHandler))
 
 	m.Handle("/profile", appHandler(app.profileHandler))
 	m.Handle("/profile/", appHandler(app.profileHandler))
@@ -434,6 +435,10 @@ func (app *App) networkInterfacesHandler(w http.ResponseWriter, r *http.Request)
 
 func (app *App) availabilityZoneHandler(w http.ResponseWriter, r *http.Request) {
 	write(w, app.AvailabilityZone)
+}
+
+func (app *App) regionHandler(w http.ResponseWriter, r *http.Request) {
+	write(w, app.AvailabilityZone[:len(app.AvailabilityZone)-1])
 }
 
 func (app *App) securityCredentialsHandler(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
This is useful when running with `host` netns and listening on `169.254.169.254`